### PR TITLE
Fix grammar in interpret_ultrafeeder_config

### DIFF
--- a/rootfs/scripts/interpret_ultrafeeder_config
+++ b/rootfs/scripts/interpret_ultrafeeder_config
@@ -2,7 +2,7 @@
 
 # shellcheck shell=bash disable=SC2015,SC2154
 #
-# This scripts should be sourced by the /etc/services.d/xxx/run modules for
+# This script should be sourced by the /etc/services.d/xxx/run modules for
 # readsb, mlat-client, and mlathub. It interprets the ULTRAFEEDER_CONFIG / ULTRAFEEDER_NET_CONNECTOR parameter
 # and makes individual net-connector strings available for these three modules.
 #


### PR DESCRIPTION
## Summary
- fix grammar in intro comment for `interpret_ultrafeeder_config`

## Testing
- `pre-commit run --files rootfs/scripts/interpret_ultrafeeder_config`
